### PR TITLE
Use `libdl.so.2` when `libdl.so` is unavailable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Build & Pack
+        run: |
+          dotnet build -c Release src/vk.generator/vk.generator.csproj
+          dotnet build -c Release src/vk.rewrite/vk.rewrite.csproj
+          dotnet pack -c Release src/vk/vk.csproj /p:Version=$(git describe --exact-match --tags HEAD)
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Vk
+          path: bin/Release/vk/ppy.*.nupkg
+
+      - name: Publish tagged release to nuget.org
+        run: dotnet nuget push bin/Release/vk/ppy.*.nupkg -s https://api.nuget.org/v3/index.json --api-key ${{secrets.NUGET_API_KEY}}

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="myget mellinoe" value="https://www.myget.org/F/mellinoe/api/v3/index.json" />
-    <add key="dotnet-myget dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="dotnet-myget dotnet-corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
-    <add key="myget SixLabors" value="https://www.myget.org/F/sixlabors/api/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/build-package.cmd
+++ b/build-package.cmd
@@ -1,4 +1,0 @@
-@echo off
-dotnet build -c Release src\Vk.Generator\Vk.Generator.csproj
-dotnet build -c Release src\Vk.Rewrite\Vk.Rewrite.csproj
-dotnet pack -c Release src\Vk\Vk.csproj

--- a/build-package.sh
+++ b/build-package.sh
@@ -1,3 +1,0 @@
-dotnet build -c Release src/Vk.Generator/Vk.Generator.csproj
-dotnet build -c Release src/Vk.Rewrite/Vk.Rewrite.csproj
-dotnet pack -c Release src/Vk/Vk.csproj

--- a/src/vk.generator/Program.cs
+++ b/src/vk.generator/Program.cs
@@ -9,61 +9,60 @@ namespace Vk.Generator
     {
         public static int Main(string[] args)
         {
-            string outputPath = AppContext.BaseDirectory;
+            Option<DirectoryInfo> outputPathOpt = new Option<DirectoryInfo>(
+                ["-o", "--out"],
+                () => new DirectoryInfo(AppContext.BaseDirectory),
+                "The folder into which code is generated. Defaults to the application directory.");
 
-            ArgumentSyntax.Parse(args, s =>
-            {
-                s.DefineOption("o|out", ref outputPath, "The folder into which code is generated. Defaults to the application directory.");
-            });
+            RootCommand cmd = new RootCommand();
+            cmd.AddOption(outputPathOpt);
 
-            Configuration.CodeOutputPath = outputPath;
+            cmd.SetHandler(outputPath =>
+            {
+                Configuration.CodeOutputPath = outputPath.FullName;
 
-            if (File.Exists(outputPath))
-            {
-                Console.Error.WriteLine("The given path is a file, not a folder.");
-                return 1;
-            }
-            else if (!Directory.Exists(outputPath))
-            {
-                Directory.CreateDirectory(outputPath);
-            }
-
-            using (var fs = File.OpenRead(Path.Combine(AppContext.BaseDirectory, "vk.xml")))
-            {
-                VulkanSpecification vs = VulkanSpecification.LoadFromXmlStream(fs);
-                TypeNameMappings tnm = new TypeNameMappings();
-                foreach (var typedef in vs.Typedefs)
+                if (!outputPath.Exists)
                 {
-                    if (typedef.Requires != null)
-                    {
-                        tnm.AddMapping(typedef.Requires, typedef.Name);
-                    }
-                    else
-                    {
-                        tnm.AddMapping(typedef.Name, "uint");
-                    }
+                    outputPath.Create();
                 }
 
-                HashSet<string> definedBaseTypes = new HashSet<string>
+                using (var fs = File.OpenRead(Path.Combine(AppContext.BaseDirectory, "vk.xml")))
                 {
-                    "VkBool32"
-                };
-
-                if (Configuration.MapBaseTypes)
-                {
-                    foreach (var baseType in vs.BaseTypes)
+                    VulkanSpecification vs = VulkanSpecification.LoadFromXmlStream(fs);
+                    TypeNameMappings tnm = new TypeNameMappings();
+                    foreach (var typedef in vs.Typedefs)
                     {
-                        if (!definedBaseTypes.Contains(baseType.Key))
+                        if (typedef.Requires != null)
                         {
-                            tnm.AddMapping(baseType.Key, baseType.Value);
+                            tnm.AddMapping(typedef.Requires, typedef.Name);
+                        }
+                        else
+                        {
+                            tnm.AddMapping(typedef.Name, "uint");
                         }
                     }
+
+                    HashSet<string> definedBaseTypes = new HashSet<string>
+                    {
+                        "VkBool32"
+                    };
+
+                    if (Configuration.MapBaseTypes)
+                    {
+                        foreach (var baseType in vs.BaseTypes)
+                        {
+                            if (!definedBaseTypes.Contains(baseType.Key))
+                            {
+                                tnm.AddMapping(baseType.Key, baseType.Value);
+                            }
+                        }
+                    }
+
+                    CodeGenerator.GenerateCodeFiles(vs, tnm, Configuration.CodeOutputPath);
                 }
+            }, outputPathOpt);
 
-                CodeGenerator.GenerateCodeFiles(vs, tnm, Configuration.CodeOutputPath);
-            }
-
-            return 0;
+            return cmd.Invoke(args);
         }
     }
 }

--- a/src/vk.generator/vk.generator.csproj
+++ b/src/vk.generator/vk.generator.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyName>vk.generator</AssemblyName>
     <RootNamespace>Vk.Generator</RootNamespace>
@@ -12,6 +12,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </Content>
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e160908-1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 </Project>

--- a/src/vk.rewrite/vk.rewrite.csproj
+++ b/src/vk.rewrite/vk.rewrite.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Build;Publish">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyName>vk.rewrite</AssemblyName>
     <RootNamespace>Vk.Generator.Rewrite</RootNamespace>
@@ -8,7 +8,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e160908-1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0-beta7" />
   </ItemGroup>
 </Project>

--- a/src/vk/Libdl.cs
+++ b/src/vk/Libdl.cs
@@ -5,18 +5,62 @@ namespace Vulkan
 {
     internal static class Libdl
     {
-        [DllImport("libdl")]
-        public static extern IntPtr dlopen(string fileName, int flags);
+        private static class Libdl1
+        {
+            private const string LibName = "libdl";
 
-        [DllImport("libdl")]
-        public static extern IntPtr dlsym(IntPtr handle, string name);
+            [DllImport(LibName)]
+            public static extern IntPtr dlopen(string fileName, int flags);
 
-        [DllImport("libdl")]
-        public static extern int dlclose(IntPtr handle);
+            [DllImport(LibName)]
+            public static extern IntPtr dlsym(IntPtr handle, string name);
 
-        [DllImport("libdl")]
-        public static extern string dlerror();
+            [DllImport(LibName)]
+            public static extern int dlclose(IntPtr handle);
+
+            [DllImport(LibName)]
+            public static extern string dlerror();
+        }
+
+        private static class Libdl2
+        {
+            private const string LibName = "libdl.so.2";
+
+            [DllImport(LibName)]
+            public static extern IntPtr dlopen(string fileName, int flags);
+
+            [DllImport(LibName)]
+            public static extern IntPtr dlsym(IntPtr handle, string name);
+
+            [DllImport(LibName)]
+            public static extern int dlclose(IntPtr handle);
+
+            [DllImport(LibName)]
+            public static extern string dlerror();
+        }
+
+        static Libdl()
+        {
+            try
+            {
+                Libdl1.dlerror();
+                m_useLibdl1 = true;
+            }
+            catch
+            {
+            }
+        }
+
+        private static bool m_useLibdl1;
 
         public const int RTLD_NOW = 0x002;
+
+        public static IntPtr dlopen(string fileName, int flags) => m_useLibdl1 ? Libdl1.dlopen(fileName, flags) : Libdl2.dlopen(fileName, flags);
+
+        public static IntPtr dlsym(IntPtr handle, string name) => m_useLibdl1 ? Libdl1.dlsym(handle, name) : Libdl2.dlsym(handle, name);
+
+        public static int dlclose(IntPtr handle) => m_useLibdl1 ? Libdl1.dlclose(handle) : Libdl2.dlclose(handle);
+
+        public static string dlerror() => m_useLibdl1 ? Libdl1.dlerror() : Libdl2.dlerror();
     }
 }

--- a/src/vk/vk.csproj
+++ b/src/vk/vk.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net5;netstandard1.4</TargetFrameworks>
     <OutputType>Library</OutputType>
     <AssemblyName>vk</AssemblyName>
-    <AssemblyVersion>1.0.25</AssemblyVersion>
+    <AssemblyVersion>1.0.26</AssemblyVersion>
     <RootNamespace>Vulkan</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{D8573039-9FE1-4554-A659-4E77CFBA83C1}</ProjectGuid>
@@ -12,7 +12,7 @@
     <DefineConstants>$(DefineConstants);CALLI_STUBS</DefineConstants>
 
     <!-- Package Info -->
-    <PackageId>Vk</PackageId>
+    <PackageId>ppy.Vk</PackageId>
     <PackageVersion>$(AssemblyVersion)</PackageVersion>
     <Description>Low-level bindings for the Vulkan graphics and compute API.</Description>
     <PackageTags>Vulkan Graphics 3D GPU Games Khronos</PackageTags>

--- a/src/vk/vk.csproj
+++ b/src/vk/vk.csproj
@@ -26,13 +26,13 @@
   </ItemGroup>
   <Target Name="AutoGenerateBindings" BeforeTargets="CoreCompile">
     <PropertyGroup>
-      <VkGeneratorExecutable>$(BinDir)/$(Configuration)/vk.generator/netcoreapp2.0/vk.generator.dll</VkGeneratorExecutable>
+      <VkGeneratorExecutable>$(BinDir)/$(Configuration)/vk.generator/net8.0/vk.generator.dll</VkGeneratorExecutable>
     </PropertyGroup>
     <Message Text="Generating bindings." />
     <Exec Command="dotnet $(VkGeneratorExecutable) --out $(MSBuildThisFileDirectory)Generated" />
   </Target>
   <PropertyGroup>
-    <VkRewriteExecutable>$(BinDir)/$(Configuration)/vk.rewrite/netcoreapp2.0/vk.rewrite.dll</VkRewriteExecutable>
+    <VkRewriteExecutable>$(BinDir)/$(Configuration)/vk.rewrite/net8.0/vk.rewrite.dll</VkRewriteExecutable>
   </PropertyGroup>
   <Target Name="RewriteCalliStubs" AfterTargets="PostBuildEvent" Condition="'$(DisableCalli)' != 'true'">
     <Message Text="Rewriting calli stubs." />


### PR DESCRIPTION
This is the bare minimum work required for this library to use libdl.so.2. The implementation is a copy of [`NativeLibraryLoader`](https://github.com/mellinoe/nativelibraryloader/blob/master/NativeLibraryLoader/Libdl.cs), an implementation that `Veldrid` uses. It does not use `NativeLibrary` because the project still targets `netstandard1.4`.

I originally intended to PR this upstream, but it looks like upstream is unmaintained because there was already [another](https://github.com/mellinoe/vk/pull/39) implementation aiming to fix the same thing that hasn't been merged in over a year. I didn't use that implementation because we don't target glibc v2.34.

So I've adjusted this to use the `ppy` prefix, and added tagged deploy, and intend to use it for our fork of Veldrid. It should be a once-off deploy and never touched again afterwards.

Sample deploy (failed due to no nuget perms): https://github.com/smoogipoo/vk/actions/runs/8713428105